### PR TITLE
Do not call delegate when selectedIndex is set

### DIFF
--- a/ScrubBar/ScrubBar.swift
+++ b/ScrubBar/ScrubBar.swift
@@ -179,13 +179,13 @@ public class ScrubBar: UIControl {
             isInScrubMode = true
         }
         if isInScrubMode {
-            updateSelectedIndex(location)
+            updateSelectedIndexForTouchLocation(location)
         }
 
         return true
     }
 
-    lazy var updateSelectedIndex: (CGPoint) -> Void = { location in
+    lazy var updateSelectedIndexForTouchLocation: (CGPoint) -> Void = { location in
         let previousSelectedIndex = self.selectedIndex
         let newSelectedIndex = self.itemLocator!.indexOfItem(forX: location.x)
         guard previousSelectedIndex != newSelectedIndex else { return }
@@ -228,7 +228,7 @@ public class ScrubBar: UIControl {
 
         guard let touch = touch else { return }
 
-        updateSelectedIndex(touch.location(in: self))
+        updateSelectedIndexForTouchLocation(touch.location(in: self))
     }
 
     // MARK: Cancel tracking

--- a/ScrubBar/ScrubBar.swift
+++ b/ScrubBar/ScrubBar.swift
@@ -56,8 +56,6 @@ public class ScrubBar: UIControl {
 
             imageViews[oldValue].accessibilityTraits = UIAccessibilityTraitButton
             imageViews[selectedIndex].accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitSelected
-
-            delegate?.scrubBar(self, didSelectItemAt: selectedIndex)
         }
     }
 
@@ -185,10 +183,18 @@ public class ScrubBar: UIControl {
             isInScrubMode = true
         }
         if isInScrubMode {
-            selectedIndex = itemLocator!.indexOfItem(forX: location.x)
+            updateSelectedIndex(forLocation: location)
         }
 
         return true
+    }
+
+    func updateSelectedIndex(forLocation location: CGPoint) {
+        let previousSelectedIndex = selectedIndex
+        selectedIndex = itemLocator!.indexOfItem(forX: location.x)
+        if previousSelectedIndex != selectedIndex {
+            delegate?.scrubBar(self, didSelectItemAt: selectedIndex)
+        }
     }
 
     var isInScrubMode = false {
@@ -213,7 +219,7 @@ public class ScrubBar: UIControl {
 
         guard let touch = touch else { return }
 
-        selectedIndex = itemLocator!.indexOfItem(forX: touch.location(in: self).x)
+        updateSelectedIndex(forLocation: touch.location(in: self))
     }
 
     // MARK: Cancel tracking

--- a/ScrubBarTests/ScrubBarTests.swift
+++ b/ScrubBarTests/ScrubBarTests.swift
@@ -409,7 +409,7 @@ final class ScrubBarTests: XCTestCase {
         scrubBar.itemLocator = ItemLocatorStub(indexOfItem: 1)
 
         // Act
-        scrubBar.updateSelectedIndex(.zero)
+        scrubBar.updateSelectedIndexForTouchLocation(.zero)
 
         // Assert
         let expectedAnimationConfiguration = AnimatingMock.AnimationConfiguration(duration: animationDuration, delay: 0, dampingRatio: 1, velocity: 0, options: [])
@@ -424,7 +424,7 @@ final class ScrubBarTests: XCTestCase {
         scrubBar.selectedIndex = 1
 
         // Act
-        scrubBar.updateSelectedIndex(.zero)
+        scrubBar.updateSelectedIndexForTouchLocation(.zero)
 
         // Assert
         XCTAssertEqual(AnimatingMock.capturedAnimationConfigurations, [])
@@ -445,7 +445,7 @@ final class ScrubBarTests: XCTestCase {
         scrubBar?.itemLocator = ItemLocatorStub(indexOfItem: selectedIndex)
 
         // Act
-        scrubBar?.updateSelectedIndex(.zero)
+        scrubBar?.updateSelectedIndexForTouchLocation(.zero)
         AnimatingMock.capturedAnimations.first?()
 
         // Assert
@@ -758,7 +758,7 @@ final class ScrubBarTests: XCTestCase {
         let delegateMock = ScrubBarDelegateMock()
         scrubBar.delegate = delegateMock
         scrubBar.itemLocator = ItemLocatorStub(indexOfItem: selectedIndex)
-        scrubBar.updateSelectedIndex(.zero)
+        scrubBar.updateSelectedIndexForTouchLocation(.zero)
         XCTAssertEqual(delegateMock.capturedScrubBars, [scrubBar], file: file, line: line)
         XCTAssertEqual(delegateMock.capturedIndexes, [selectedIndex], file: file, line: line)
     }
@@ -768,34 +768,34 @@ final class ScrubBarTests: XCTestCase {
         scrubBar.delegate = delegateMock
         scrubBar.itemLocator = ItemLocatorStub(indexOfItem: 1)
         scrubBar.selectedIndex = 1
-        scrubBar.updateSelectedIndex(.zero)
+        scrubBar.updateSelectedIndexForTouchLocation(.zero)
         XCTAssertEqual(delegateMock.capturedScrubBars, [])
         XCTAssertEqual(delegateMock.capturedIndexes, [])
     }
 
     // MARK: Updating selected index
 
-    func testUpdateSelectedIndexIsCalledWhileScrubbing() {
-        let expectCallUpdateSelectedIndex = expectation(description: "updateSelectedIndex is called")
-        scrubBar.updateSelectedIndex = { location in
-            expectCallUpdateSelectedIndex.fulfill()
+    func testupdateSelectedIndexForTouchLocationIsCalledWhileScrubbing() {
+        let expectCallupdateSelectedIndexForTouchLocation = expectation(description: "updateSelectedIndexForTouchLocation is called")
+        scrubBar.updateSelectedIndexForTouchLocation = { location in
+            expectCallupdateSelectedIndexForTouchLocation.fulfill()
         }
         scrubBar.isInScrubMode = true
         scrubBar.startTouchLocation = .zero
         _ = scrubBar.continueTracking(TouchStub(location: .zero, view: scrubBar), with: nil)
-        wait(for: [expectCallUpdateSelectedIndex], timeout: 0)
+        wait(for: [expectCallupdateSelectedIndexForTouchLocation], timeout: 0)
     }
 
-    func testUpdateSelectedIndexIsCalledWhenTouchEnds() {
-        let expectCallUpdateSelectedIndex = expectation(description: "updateSelectedIndex is called")
-        scrubBar.updateSelectedIndex = { location in
-            expectCallUpdateSelectedIndex.fulfill()
+    func testupdateSelectedIndexForTouchLocationIsCalledWhenTouchEnds() {
+        let expectCallupdateSelectedIndexForTouchLocation = expectation(description: "updateSelectedIndexForTouchLocation is called")
+        scrubBar.updateSelectedIndexForTouchLocation = { location in
+            expectCallupdateSelectedIndexForTouchLocation.fulfill()
         }
         let delegateMock = ScrubBarDelegateMock()
         scrubBar.delegate = delegateMock
         scrubBar.itemLocator = ItemLocatorStub(indexOfItem: 1)
         scrubBar.endTracking(TouchStub(location: .zero, view: scrubBar), with: nil)
-        wait(for: [expectCallUpdateSelectedIndex], timeout: 0)
+        wait(for: [expectCallupdateSelectedIndexForTouchLocation], timeout: 0)
     }
 
 }

--- a/ScrubBarTests/ScrubBarTests.swift
+++ b/ScrubBarTests/ScrubBarTests.swift
@@ -775,7 +775,7 @@ final class ScrubBarTests: XCTestCase {
 
     // MARK: Updating selected index
 
-    func testupdateSelectedIndexForTouchLocationIsCalledWhileScrubbing() {
+    func testUpdateSelectedIndexForTouchLocationIsCalledWhileScrubbing() {
         let expectCallupdateSelectedIndexForTouchLocation = expectation(description: "updateSelectedIndexForTouchLocation is called")
         scrubBar.updateSelectedIndexForTouchLocation = { location in
             expectCallupdateSelectedIndexForTouchLocation.fulfill()
@@ -786,7 +786,7 @@ final class ScrubBarTests: XCTestCase {
         wait(for: [expectCallupdateSelectedIndexForTouchLocation], timeout: 0)
     }
 
-    func testupdateSelectedIndexForTouchLocationIsCalledWhenTouchEnds() {
+    func testUpdateSelectedIndexForTouchLocationIsCalledWhenTouchEnds() {
         let expectCallupdateSelectedIndexForTouchLocation = expectation(description: "updateSelectedIndexForTouchLocation is called")
         scrubBar.updateSelectedIndexForTouchLocation = { location in
             expectCallupdateSelectedIndexForTouchLocation.fulfill()

--- a/ScrubBarTests/ScrubBarTests.swift
+++ b/ScrubBarTests/ScrubBarTests.swift
@@ -778,7 +778,7 @@ class TouchStub: UITouch {
 
     override func location(in view: UIView?) -> CGPoint {
         guard view == self.touchView else {
-            XCTFail("View is not equal to \(self.view)")
+            XCTFail("View is not equal to \(String(describing: self.view))")
             return .zero
         }
         return location

--- a/ScrubBarTests/ScrubBarTests.swift
+++ b/ScrubBarTests/ScrubBarTests.swift
@@ -735,33 +735,54 @@ final class ScrubBarTests: XCTestCase {
         XCTAssertNil(scrubBar.delegate)
     }
 
-    func testDelegateIsCalledWithSelf() {
+    func testDelegateIsCalledWhileScrubbing1() { testDelegateIsCalledWhileScrubbing(withSelectedIndex: 1) }
+    func testDelegateIsCalledWhileScrubbing2() { testDelegateIsCalledWhileScrubbing(withSelectedIndex: 2) }
+
+    func testDelegateIsCalledWhileScrubbing(withSelectedIndex selectedIndex: Int, file: StaticString = #file, line: UInt = #line) {
         let delegateMock = ScrubBarDelegateMock()
         scrubBar.delegate = delegateMock
+        scrubBar.isInScrubMode = true
+        scrubBar.itemLocator = ItemLocatorStub(indexOfItem: selectedIndex)
+        scrubBar.startTouchLocation = .zero
+        scrubBar.selectedIndex = 0
+        _ = scrubBar.continueTracking(TouchStub(location: .zero, view: scrubBar), with: nil)
+        XCTAssertEqual(delegateMock.capturedScrubBars, [scrubBar], file: file, line: line)
+        XCTAssertEqual(delegateMock.capturedIndexes, [selectedIndex], file: file, line: line)
+    }
+
+    func testDelegateIsNotCalledWhileScrubbingIfSelectedIndexDoesNotChange() {
+        let delegateMock = ScrubBarDelegateMock()
+        scrubBar.delegate = delegateMock
+        scrubBar.isInScrubMode = true
+        scrubBar.itemLocator = ItemLocatorStub(indexOfItem: 1)
+        scrubBar.startTouchLocation = .zero
         scrubBar.selectedIndex = 1
-        XCTAssertEqual(delegateMock.capturedScrubBars, [scrubBar])
+        _ = scrubBar.continueTracking(TouchStub(location: .zero, view: scrubBar), with: nil)
+        XCTAssertEqual(delegateMock.capturedScrubBars, [])
+        XCTAssertEqual(delegateMock.capturedIndexes, [])
     }
 
-    func testDelegateIsCalledWithSelectedItemIndex1() { testDelegateIsCalledWithSelectedItemIndex(withItemIndex: 1) }
-    func testDelegateIsCalledWithSelectedItemIndex2() { testDelegateIsCalledWithSelectedItemIndex(withItemIndex: 2) }
+    func testDelegateIsCalledWhenTouchEnds1() { testDelegateIsCalledWhenTouchEnds(withSelectedIndex: 1) }
+    func testDelegateIsCalledWhenTouchEnds2() { testDelegateIsCalledWhenTouchEnds(withSelectedIndex: 2) }
 
-    func testDelegateIsCalledWithSelectedItemIndex(withItemIndex itemIndex: Int, file: StaticString = #file, line: UInt = #line) {
+    func testDelegateIsCalledWhenTouchEnds(withSelectedIndex selectedIndex: Int, file: StaticString = #file, line: UInt = #line) {
         let delegateMock = ScrubBarDelegateMock()
         scrubBar.delegate = delegateMock
-        scrubBar.selectedIndex = itemIndex
-        XCTAssertEqual(delegateMock.capturedIndexes, [itemIndex], file: file, line: line)
+        scrubBar.itemLocator = ItemLocatorStub(indexOfItem: selectedIndex)
+        scrubBar.selectedIndex = 0
+        scrubBar.endTracking(TouchStub(location: .zero, view: scrubBar), with: nil)
+        XCTAssertEqual(delegateMock.capturedScrubBars, [scrubBar], file: file, line: line)
+        XCTAssertEqual(delegateMock.capturedIndexes, [selectedIndex], file: file, line: line)
     }
 
-    func testDelegateIsCalledOnlyOnChange1() { testDelegateIsCalledOnlyOnChange(withItemIndex: 0) }
-    func testDelegateIsCalledOnlyOnChange2() { testDelegateIsCalledOnlyOnChange(withItemIndex: 1) }
-
-    func testDelegateIsCalledOnlyOnChange(withItemIndex itemIndex: Int, file: StaticString = #file, line: UInt = #line) {
+    func testDelegateIsNotCalledWhenTouchEndsIfSelectedIndexDoesNotChange() {
         let delegateMock = ScrubBarDelegateMock()
-        let scrubBar = ScrubBar(items: [.empty(), .empty(), .empty()])!
-        scrubBar.selectedIndex = itemIndex
         scrubBar.delegate = delegateMock
-        scrubBar.selectedIndex = itemIndex
-        XCTAssertEqual(delegateMock.capturedIndexes, [], file: file, line: line)
+        scrubBar.itemLocator = ItemLocatorStub(indexOfItem: 1)
+        scrubBar.selectedIndex = 1
+        scrubBar.endTracking(TouchStub(location: .zero, view: scrubBar), with: nil)
+        XCTAssertEqual(delegateMock.capturedScrubBars, [])
+        XCTAssertEqual(delegateMock.capturedIndexes, [])
     }
 
 }


### PR DESCRIPTION
Also does not start animation when `selectedIndex` is set via property